### PR TITLE
Fixed failure of networking tests.

### DIFF
--- a/tests/vmi_networking_test.go
+++ b/tests/vmi_networking_test.go
@@ -153,8 +153,8 @@ var _ = Describe("Networking", func() {
 				tests.SkipIfOpenShift("Custom MAC addresses on pod networks are not supported")
 			}
 
-			// assuming pod network is of standard MTU = 1500 (minus 50 bytes for vxlan overhead)
-			expectedMtu := 1450
+			// Default MTU in Cirros VMs is 1400.
+			expectedMtu := 1400
 			ipHeaderSize := 28 // IPv4 specific
 			payloadSize := expectedMtu - ipHeaderSize
 


### PR DESCRIPTION
This PR fixes a failed tier1 test.
The failed test expects a wrong value of the default MTU of a VM's pod interface, and the fix includes the correct expected MTU value.